### PR TITLE
A2 failing test - declaration-no-statement

### DIFF
--- a/a2/tests/failing/declaration-and-statement/declaration-no-statement.488
+++ b/a2/tests/failing/declaration-and-statement/declaration-no-statement.488
@@ -1,0 +1,4 @@
+% Program cannot contain only declaration
+{
+	var a : integer
+}

--- a/a2/tests/failing/doc.txt
+++ b/a2/tests/failing/doc.txt
@@ -13,6 +13,7 @@ array-no-rsquare.488			: Checks for array declaration where right squared bracke
 array-wrong-parenthesis.488		: Should get syntax error if user declares an array with parenthesis rather than square brackets.
 broken-if-structure.488			: `if` statements should always have 'then' and 'else' in correct order. Parser should throw an error otherwise.
 declaration-in-middle.488		: Since our language only supports declaration first, then statement (in a given scope), this test checks that syntax error occurs if there is declaration in the middle.
+declaration-no-statement.488		: Program does not support programs with only declaration. This test checks whether our compiler throws an error
 ident-starts-with-integer.488		: All identifiers should not start with numbers. This test will check if we get syntax error if it does.
 if-mult-stmt-no-scope.488		: We are expected for if statement body to use scope if it requires multiple statements. Otherwise, syntax error should occur
 keyword-as-var-name.488			: This test checks whether error occurs if user attempts to make a variable with keyword as identifier.


### PR DESCRIPTION
Added another fail scenario. Simply checks if our parser throws an error if we have a program with only declaration(s)