### PR TITLE
A3 semantic action routines

### DIFF
--- a/a3/src/compiler488/ast/ASTList.java
+++ b/a3/src/compiler488/ast/ASTList.java
@@ -20,11 +20,14 @@ import java.util.LinkedList;
 public class ASTList<E extends AST> extends LinkedList<E> implements AST {
 	private static final long serialVersionUID = 1L;
 
+	private int count;
+
 	/**
 	 * Create an empty AST list
 	 */
 	public ASTList() {
 		super();
+		this.count = 0;
 	}
 
 	/**
@@ -37,6 +40,7 @@ public class ASTList<E extends AST> extends LinkedList<E> implements AST {
 		this();
 
 		append(elem);
+		this.count = 1;
 	}
 
 	/**
@@ -54,6 +58,7 @@ public class ASTList<E extends AST> extends LinkedList<E> implements AST {
 	 */
 	public ASTList<E> append(E elem) {
 		addLast(elem);
+		this.count++;
 
 		return this;
 	}
@@ -86,6 +91,10 @@ public class ASTList<E extends AST> extends LinkedList<E> implements AST {
 
 			first = false;
 		}
+	}
+
+	public int getCounter() {
+		return this.count;
 	}
 
 	/**

--- a/a3/src/compiler488/semantics/Semantics.java
+++ b/a3/src/compiler488/semantics/Semantics.java
@@ -181,7 +181,7 @@ public class Semantics extends AST_Visitor.Default {
 		analyzers.put(47, (s, self) -> {
 			// TODO(golaubka): Seems like the type is already stored in the associated Decl class.
 		});
-		
+
 		// ===== FUNCTIONS, PROCEDURES AND ARGUMENTS ===== //
 		analyzers.put(40, (s, self) -> {
 			assert(s.get(0) instanceof FunctionCallExpn);
@@ -191,13 +191,38 @@ public class Semantics extends AST_Visitor.Default {
 			assert(routine.getType() != null);
 		});
 		analyzers.put(41, (s, self) -> {
-
+			assert(s.get(0) instanceof ProcedureCallStmt);
+			ProcedureCallStmt procStmt = (ProcedureCallStmt) s.get(0);
+			assert(symTable.Get(procStmt.getName()) instanceof RoutineDecl);
+			RoutineDecl routine = (RoutineDecl) symTable.Get(procStmt.getName());
+			assert(routine.getType() == null);
 		});
 		analyzers.put(42, (s, self) -> {
-
+			if(s.get(0) instanceof FunctionCallExpn) {
+				FunctionCallExpn funcExpn = (FunctionCallExpn) s.get(0);
+				assert(funcExpn.getArguments() == null);
+			} else if(s.get(0) instanceof ProcedureCallStmt) {
+				ProcedureCallStmt procStmt = (ProcedureCallStmt) s.get(0);
+				assert(procStmt.getArguments() == null);
+			} else {
+				assert(false);
+			}
 		});
 		analyzers.put(43, (s, self) -> {
-
+			RoutineDecl routine;
+			if(s.get(0) instanceof FunctionCallExpn) {
+				FunctionCallExpn funcExpn = (FunctionCallExpn) s.get(0);
+				routine = (RoutineDecl) symTable.Get(funcExpn.getIdent());
+				assert(routine.getParameters().getCounter()
+						!= funcExpn.getArguments().getCounter());
+			} else if(s.get(0) instanceof ProcedureCallStmt) {
+				ProcedureCallStmt procStmt = (ProcedureCallStmt) s.get(0);
+				routine = (RoutineDecl) symTable.Get(procStmt.getName());
+				assert(routine.getParameters().getCounter()
+						!= procStmt.getArguments().getCounter());
+			} else {
+				assert(false);
+			}
 		});
 		analyzers.put(44, (s, self) -> {
 
@@ -205,13 +230,13 @@ public class Semantics extends AST_Visitor.Default {
 		analyzers.put(45, (s, self) -> {
 
 		});
-		
+
 		// Custom semantic action -- new loop. Need to create a new context
 		analyzers.put(98, (s, self) -> {
 			Context newContext = new Context(this.context, ContextType.LOOP);
 			this.context = newContext;
 		});
-		
+
 		// Custom semantic action -- exit context. Need to switch to previous context
 		analyzers.put(99, (s, self) -> {
 			this.context = this.context.GetPrev();

--- a/a3/src/compiler488/semantics/semanticsdoc.txt
+++ b/a3/src/compiler488/semantics/semanticsdoc.txt
@@ -1,0 +1,6 @@
+Parameters & Arguments counter:
+    Instead of counting number of parameters and/or arguments of a given
+    procedure/function declaration and call, we have decided to embed counter
+    variable within ASTList (which is what parameters and arguments are).
+    As such, we have omitted S14, S16, S44, and S45. Instead, we can simply
+    just compare the counter of ASTList of parameters and arguments.


### PR DESCRIPTION
Merged #56 and #55. 

Notice that 44 and 45 are left blank. This is due to the fact that ASTList now has counter, meaning we don't need to count the parameters as well. Explained in "semanticsdoc.txt"